### PR TITLE
Add download as TSV feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv
 replit_zip*
 .DS_Store
 .breakpoints
+emails.db

--- a/main.py
+++ b/main.py
@@ -229,7 +229,14 @@ def results():
                            longest_to_address=longest_to_address, 
                            longest_message_id=longest_message_id, 
                            multi_selectors=multi_selectors)
-    
+# convert {k1: [v1, v2, …], k2: [v3, v4, …]} to TSV with one line per key-value pair
+def dict_to_tsv(dict):
+    res = ""
+    for k, vArr in dict.items():
+        for v in vArr:
+            res += f'{k}\t{v}\n'
+    return res
+
 # Route for retrieving and displaying the results
 @app.route('/get_selectors')
 def get_selectors():
@@ -247,6 +254,8 @@ def get_selectors():
     
     for selector_domain in raw_results:
         selector, domain = selector_domain
+        if not selector or not domain:
+            continue
         if selector not in grouped_by_selectors:
             grouped_by_selectors[selector] = []
         grouped_by_selectors[selector].append(domain)
@@ -259,7 +268,8 @@ def get_selectors():
     grouped_by_selectors = {k: v for k, v in sorted(grouped_by_selectors.items(), key=lambda item: len(item[1]), reverse=True)}
     grouped_by_domains = {k: v for k, v in sorted(grouped_by_domains.items(), key=lambda item: len(item[1]), reverse=True)}
     
-    return render_template('selectors.html', selectors=grouped_by_selectors, domains=grouped_by_domains)
+    tsv_by_domain = dict_to_tsv(grouped_by_domains)
+    return render_template('selectors.html', selectors=grouped_by_selectors, domains=grouped_by_domains, tsv_by_domain=tsv_by_domain)
 
 if __name__ == '__main__':
     app.run('127.0.0.1', debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ google-auth-oauthlib
 google-auth-httplib2
 google-auth
 gunicorn
-dotenv
+python-dotenv
+Werkzeug==2.3.8

--- a/templates/selectors.html
+++ b/templates/selectors.html
@@ -25,6 +25,16 @@
                 domainsView.style.display = "block";
             }
         }
+
+        function download(filename, text) {
+            var element = document.createElement('a');
+            element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+            element.setAttribute('download', filename);
+            element.style.display = 'none';
+            document.body.appendChild(element);
+            element.click();
+            document.body.removeChild(element);
+        }
     </script>
 </head>
 <body>
@@ -35,9 +45,9 @@
         <div id="selectorsView">
             {% for result in selectors %}
             <div class="card">
-                <div class="card-header">{{ result }}</div>
+                <div class="card-header">Selector: {{ result }}</div>
                 <div class="card-body">
-                    <p>Selector: {{ selectors[result] }}</p>
+                    <p>Domains: {{ selectors[result] }}</p>
                     <button onclick="copyToClipboard('{{ result }}: {{ selectors[result] }}')">Copy</button>
                 </div>
             </div>
@@ -46,13 +56,18 @@
         <div id="domainsView" style="display: none;">
             {% for result in domains %}
             <div class="card">
-                <div class="card-header">{{ result }}</div>
+                <div class="card-header">Domain: {{ result }}</div>
                 <div class="card-body">
-                    <p>Domain: {{ domains[result] }}</p>
+                    <p>Selectors: {{ domains[result] }}</p>
                     <button onclick="copyToClipboard('{{ result }}: {{ domains[result] }}')">Copy</button>
                 </div>
             </div>
             {% endfor %}
+        </div>
+        <div id="domainsTsvView">
+            <h2>Domains TSV</h2>
+            <button onclick="download('domains_selectors.tsv', document.getElementById('tsvDataTextArea').value)">Download TSV file</button>
+            <textarea id="tsvDataTextArea" readonly rows="20" cols="100" style="font-family: monospace;">{{ tsv_by_domain }}</textarea>
         </div>
     </div>
 </body>


### PR DESCRIPTION
- Add feature to download the results (domains+selectors) as a TSV file (The TSV file can then be used with https://github.com/foolo/dkim-lookup/tree/main/dkim-lookup-app#fetch-dkim-keys-from-dns-and-upload-to-database )

- Fixed rendering of "Domains" and "Selectors" in ```selectors.html``` (the words were swapped before)

- Small fix in ```requirements.txt```, and added email.db to ```.gitignore```